### PR TITLE
fix: semicolon between categories and keyworks to keywords

### DIFF
--- a/snap/gui/excel.desktop
+++ b/snap/gui/excel.desktop
@@ -7,5 +7,5 @@ Type=Application
 Icon=${SNAP}/snap/gui/excel.png
 Exec=unofficial-webapp-office.excel
 Terminal=false
-Keyworks=Excel,spreadsheet
-Categories=Office,Spreadsheet
+Keywords=Excel,spreadsheet
+Categories=Office;Spreadsheet

--- a/snap/gui/onedrive.desktop
+++ b/snap/gui/onedrive.desktop
@@ -7,5 +7,5 @@ Type=Application
 Icon=${SNAP}/snap/gui/onedrive.png
 Exec=unofficial-webapp-office.onedrive
 Terminal=false
-Keyworks=OneDrive,files,cloud,photos
-Categories=Office,FileTransfer,Qt
+Keywords=OneDrive,files,cloud,photos
+Categories=Office;FileTransfer;Qt

--- a/snap/gui/onenote.desktop
+++ b/snap/gui/onenote.desktop
@@ -7,5 +7,5 @@ Type=Application
 Icon=${SNAP}/snap/gui/onenote.png
 Exec=unofficial-webapp-office.onenote
 Terminal=false
-Keyworks=OneNote,note,notes,notepad
-Categories=Office,ProjectManagement,Qt
+Keywords=OneNote,note,notes,notepad
+Categories=Office;ProjectManagement;Qt

--- a/snap/gui/outlook.desktop
+++ b/snap/gui/outlook.desktop
@@ -7,5 +7,5 @@ Type=Application
 Icon=${SNAP}/snap/gui/outlook.png
 Exec=unofficial-webapp-office.outlook
 Terminal=false
-Keyworks=Outlook,mail,email,calendar,contacts
-Categories=Office,Email,Calendar,ContactManagement,Qt
+Keywords=Outlook,mail,email,calendar,contacts
+Categories=Office;Email;Calendar;ContactManagement;Qt

--- a/snap/gui/powerpoint.desktop
+++ b/snap/gui/powerpoint.desktop
@@ -7,5 +7,5 @@ Type=Application
 Icon=${SNAP}/snap/gui/powerpoint.png
 Exec=unofficial-webapp-office.powerpoint
 Terminal=false
-Keyworks=PowerPoint,presentation,ppt
-Categories=Office,Presentation,Qt
+Keywords=PowerPoint,presentation,ppt
+Categories=Office;Presentation;Qt

--- a/snap/gui/word.desktop
+++ b/snap/gui/word.desktop
@@ -7,5 +7,5 @@ Type=Application
 Icon=${SNAP}/snap/gui/word.png
 Exec=unofficial-webapp-office.word
 Terminal=false
-Keyworks=Word,document,doc
-Categories=Office,WordProcessor,Qt
+Keywords=Word,document,doc
+Categories=Office;WordProcessor;Qt


### PR DESCRIPTION
As stated on [related Gnome documentation](https://help.gnome.org/admin//system-admin-guide/2.32/menustructure-desktopentry.html.en) and [related Arch Wiki Documentation](https://wiki.archlinux.org/index.php/Desktop_entries), categories should be separated by semicolon, thefore fixes it.

Also changed keyworks to keywords.

Fixes #10 